### PR TITLE
Update liqwid-nix, ignore clear dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ TAGS
 *.hoo
 *.warn
 haddock/
+
+# Other stuff
+clear\ /

--- a/flake.lock
+++ b/flake.lock
@@ -1869,11 +1869,11 @@
         "nixpkgs-2205": "nixpkgs-2205"
       },
       "locked": {
-        "lastModified": 1660580223,
-        "narHash": "sha256-r1i92rrUjSBdnQZpHLxeCAtVGMHYqKQHm05mzddIte8=",
+        "lastModified": 1666695559,
+        "narHash": "sha256-v8DcNma4hAgLCbPHpsxNYzeMURfbxh20VXfFzUED6bs=",
         "owner": "Liqwid-Labs",
         "repo": "liqwid-nix",
-        "rev": "fa1eeba35b37ac2551a00798dffdf053879699c3",
+        "rev": "7add1f24e9360e96b2bab4a1fc7929d4fa649439",
         "type": "github"
       },
       "original": {

--- a/src/Plutarch/Test/Precompiled.hs
+++ b/src/Plutarch/Test/Precompiled.hs
@@ -170,7 +170,7 @@ newtype TestCompiled a = TestCompiled
  @since 1.1.0
 -}
 withApplied :: [Data] -> TestCompiled () -> TestCompiled ()
-withApplied args = local (flip applyDebuggableScript args)
+withApplied args = local (`applyDebuggableScript` args)
 
 {- | An operator for 'withApplied'.
 


### PR DESCRIPTION
This has us use the latest `liqwid-nix`. The update caught a few changes on the linter, but otherwise should be problem-free.