### PR TITLE
Use maxBound integers for exunits limit when running debugScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ result
 result-*
 
 # direnv
-#.envrc
+.envrc
 .direnv
 
 *.sw*

--- a/src/Plutarch/Test/Script.hs
+++ b/src/Plutarch/Test/Script.hs
@@ -41,9 +41,8 @@ import Test.Tasty.Providers (
 import Plutarch.Evaluate (evalScript')
 import PlutusLedgerApi.V2 (
   Script,
- )
-import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (ExBudget))
-import PlutusCore.Evaluation.Machine.ExBudget (ExMemory (ExMemory), ExCpu (ExCpu))
+  ExBudget (ExBudget),
+  ExMemory (ExMemory), ExCpu (ExCpu))
 import Test.Tasty (testGroup)
 
 --------------------------------------------------------------------------------

--- a/src/Plutarch/Test/Script.hs
+++ b/src/Plutarch/Test/Script.hs
@@ -40,9 +40,11 @@ import Test.Tasty.Providers (
 
 import Plutarch.Evaluate (evalScript')
 import PlutusLedgerApi.V2 (
-  Script,
   ExBudget (ExBudget),
-  ExMemory (ExMemory), ExCpu (ExCpu))
+  ExCPU (ExCPU),
+  ExMemory (ExMemory),
+  Script,
+ )
 import Test.Tasty (testGroup)
 
 --------------------------------------------------------------------------------
@@ -152,9 +154,9 @@ runScript script debug onSuccess = case scriptResult of
   (Right _, _, _) -> (ScriptSuccess, onSuccess)
   (Left err, _, _) -> (ScriptFailure, showError dTrace (show err))
   where
-    scriptResult = evalScript' maxBound script
-    (_, _, dTrace) = evalScript' maxBound debug
-    budget = ExBudget (ExCpu maxBound) (ExMemory maxBound)
+    scriptResult = evalScript' budget script
+    (_, _, dTrace) = evalScript' budget debug
+    budget = ExBudget (ExCPU maxBound) (ExMemory maxBound)
 
 showError :: [Text] -> String -> String
 showError traces err =

--- a/src/Plutarch/Test/Script.hs
+++ b/src/Plutarch/Test/Script.hs
@@ -38,10 +38,12 @@ import Test.Tasty.Providers (
 
 --------------------------------------------------------------------------------
 
-import Plutarch.Evaluate (evalScript)
+import Plutarch.Evaluate (evalScript')
 import PlutusLedgerApi.V2 (
   Script,
  )
+import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (ExBudget))
+import PlutusCore.Evaluation.Machine.ExBudget (ExMemory (ExMemory), ExCpu (ExCpu))
 import Test.Tasty (testGroup)
 
 --------------------------------------------------------------------------------
@@ -151,8 +153,9 @@ runScript script debug onSuccess = case scriptResult of
   (Right _, _, _) -> (ScriptSuccess, onSuccess)
   (Left err, _, _) -> (ScriptFailure, showError dTrace (show err))
   where
-    scriptResult = evalScript script
-    (_, _, dTrace) = evalScript debug
+    scriptResult = evalScript' maxBound script
+    (_, _, dTrace) = evalScript' maxBound debug
+    budget = ExBudget (ExCpu maxBound) (ExMemory maxBound)
 
 showError :: [Text] -> String -> String
 showError traces err =


### PR DESCRIPTION
Trying to use this branch ran into some dependency hell - should probably wait until after liqwid-nix is ready for this